### PR TITLE
Use github key for extra-deps in stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -9,9 +9,9 @@ extra-deps:
 - network-3.0.1.1
 - these-1.0.1
 - semialign-1
-- git: git@github.com:hamler-lang/CoreErlang.git
+- github: hamler-lang/CoreErlang
   commit: afb0b731ff457d278403ab4bc134d3c88e09ea1f
-- git: git@github.com:hamler-lang/purescript.git
+- github: hamler-lang/purescript
   commit: 2c43709229b12e72dfc550ccf3efce6bfa60da72
 flags:
   these:


### PR DESCRIPTION
when build hamler in environment that not setup ssh for git (e.g. docker or each CI/CD), raise this error:

```
Step 6/7 : RUN git clone --branch=v$HAMLER_VERSION --depth=1 https://github.com/hamler-lang/hamler.git
 ---> Running in 9ab9fdd9315e
...
Step 7/7 : RUN cd hamler && make && make install
 ---> Running in 3aabd115cfa3
STACK_YAML="stack.yaml" stack run build -- -l
Getting project config file from STACK_YAML environment
Cabal file info not found for happy-1.19.9, updating
Selected mirror https://s3.amazonaws.com/hackage.fpcomplete.com/
Downloading root
...
Package index cache populated
Cloning afb0b731ff457d278403ab4bc134d3c88e09ea1f from git@github.com:hamler-lang/CoreErlang.git
Received ExitFailure 128 when running
Raw command: /usr/bin/git clone git@github.com:hamler-lang/CoreErlang.git /tmp/with-repo10/cloned
Standard error:

Cloning into '/tmp/with-repo10/cloned'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.

make: *** [Makefile:9: build] Error 1
```

`git: git@github.com:owner/name` is fetch repository by ssh.
So, should use `github` key that fetch repository by https.
(or `git: https://github.com/owner/name`)