### PR TITLE
Add the (>>) operator to Control.Monad under the name `bindUnit`

### DIFF
--- a/lib/Control/Monad.hm
+++ b/lib/Control/Monad.hm
@@ -13,7 +13,7 @@
 --
 -----------------------------------------------------------------------------
 module Control.Monad
-  ( class Monad, bind, (>>=), return
+  ( class Monad, bind, (>>), (>>=), return
   , liftM1, liftM2, liftM3, liftM4
   , IO
   , discard
@@ -94,5 +94,13 @@ guardF :: Boolean  -> [Boolean]
 guardF true = [true]
 guardF false = []
 
+-- | Sequentially compose two actions, discarding any value produced
+-- by the first.
+-- This can be used to end a pipeline of monadic actions with Unit:
+-- > action1 >>= action2 >>= action3 >> pure ()
+bindUnit :: forall a b. m a -> m b -> m b
+bindUnit m k = m >>= \_ -> k
+
+infixl 1 bindUnit as >>
 
 foreign import seqio ::forall a.[IO a] -> IO [a]


### PR DESCRIPTION
This operator is frequently used to end pipelines of monadic actions with `pure ()`.

A (somewhat trivial) example is:

```haskell
main :: IO ()                          
main = checkPasswordLength "test 123"  
       >>= cleanWhitespace             
       >> pure ()                     
```

Edit: I am getting this error:

```
Error found:
at lib/Control/Monad.hm:104:22 - 104:22 (line 104, column 22 - line 104, column 22)

  Unable to parse module:
  Unexpected or mismatched indentation


or to contribute content related to this error.
```