### PR TITLE
fix(Env): fix some build errors in macOS 10.15.5

### DIFF
--- a/Env
+++ b/Env
@@ -1,1 +1,1 @@
-path /usr/lib/hamler
+path /usr/local/lib/hamler

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ exe_target = hamler
 stack_yaml = STACK_YAML="stack.yaml"
 stack = $(stack_yaml) stack
 
+ifeq ($(shell uname -s),Darwin)
+hamler_lib := $(shell sed -E 's/^path (.*)/\1/g' $(CURDIR)/Env)
+else
 hamler_lib := $(shell sed -r 's/^path (.*)/\1/g' $(CURDIR)/Env)
+endif
 
 all: build
 


### PR DESCRIPTION
In macOS 10.15.5 version, the path /usr/lib/hamler can not be created because no permission even use sudo before make install command.
The other issue is the sed has not option "-r" in macOS, so use "-E" replace it.