### PR TITLE
feat(REPL): support multiple ebin dirs

### DIFF
--- a/repl/replsrv
+++ b/repl/replsrv
@@ -13,7 +13,7 @@
 main([Pa, Pz, File]) ->
     Outdir = filename:dirname(File),
     true = code:add_path(Pa),
-    true = code:add_path(Pz),
+    [_ = code:add_path(P) || P <- string:tokens(Pz, ": ")],
     true = code:add_path(Outdir),
     Opts = [from_core, {outdir, Outdir}],
     reploop(#{file => File, opts => Opts}).


### PR DESCRIPTION
To support including multiple ebin dirs for `hamler real`:

```
hamler repl -s json/src -e json/ebin:jsx/ebin
```