### PR TITLE
fix(String): hasPrefix and hasSuffix

### DIFF
--- a/lib/Data/String.erl
+++ b/lib/Data/String.erl
@@ -74,8 +74,10 @@ hasPrefix(String, Prefix) ->
 
 -spec(hasSuffix(string(), suffix()) -> boolean()).
 hasSuffix(String, Suffix) ->
-    Pos = (strlen(String) - strlen(Suffix)) + 1,
-    string:equal(string:slice(String, Pos), Suffix).
+    Pos = (strlen(String) - strlen(Suffix)),
+    if Pos >= 0 -> string:equal(string:slice(String, Pos), Suffix);
+       true     -> false
+    end.
 
 -spec(indexOf(char(), string()) -> integer()).
 indexOf(Char, String) -> string:chr(String, Char).

--- a/lib/Data/String.erl
+++ b/lib/Data/String.erl
@@ -70,7 +70,7 @@ equalIgnoreCase(S1, S2) -> string:equal(S1, S2, true).
 
 -spec(hasPrefix(string(), prefix()) -> boolean()).
 hasPrefix(String, Prefix) ->
-    string:prefix(String, Prefix).
+    string:prefix(String, Prefix) /= nomatch.
 
 -spec(hasSuffix(string(), suffix()) -> boolean()).
 hasSuffix(String, Suffix) ->


### PR DESCRIPTION
### about hasPrefix

`String.hasPrefix` is not return boolean, and always return value *like* true:

```hs
> String.hasPrefix "abc" "a"
"bc"
> String.hasPrefix "abc" "b"
nomatch
> String.startsWith "abc" "a" || false
true
> String.startsWith "abc" "b" || false
true
```

The reason is that [`string:prefix/2`](https://erlang.org/doc/man/string.html#prefix-2) is return `nomatch` or string. 
So, I fixed to check that return value is not `nomatch`.

### about hasSuffix

`String.hasSuffix` is always return `false`, and occur error if suffix length more than string length:

```hs
> String.hasSuffix "abc" "c"
false
> String.hasSuffix "abc" "a"
false
> String.hasSuffix "c" "abc"
Error: error, Reason: function_clause
Stacktrace:[{string,slice,["c",-1],[{file,"string.erl"},{line,184}]},
            {'Data.String',hasSuffix,2,[]},
            {'$REPL',it,0,[]},
            {replsrv__escript__1596__45006__838946__3,reploop,1,
                [{file,"/usr/lib/hamler/bin/replsrv"},{line,31}]},
            {escript,run,2,[{file,"escript.erl"},{line,758}]},
            {escript,start,1,[{file,"escript.erl"},{line,277}]},
            {init,start_em,1,[]},
            {init,do_boot,3,[]}]
```

The reason for always false is start position `Pos` to compare suffix is wrong.
The reason for error occurs is it doesn't check that the `Pos` is positive.
So, I fixed `Pos` and add checking positive. 