### PR TITLE
docs(README): Correct links for erlang.org and haskellstack.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ $ brew install hamler
 
 **Required**
 
-+ [Erlang/OTP](erlang.org) >= 23
-+ [Haskell Stack](haskellstack.org)
++ [Erlang/OTP](https://www.erlang.org) >= 23
++ [Haskell Stack](https://haskellstack.org)
 
 **Building**
 


### PR DESCRIPTION
https://haskellstack.org redirects to https://docs.haskellstack.org/en/stable/README, so if necessary, we could as well use that. 