### PR TITLE
feat(Monad): Reader

### DIFF
--- a/lib/Control/Monad/Reader.hm
+++ b/lib/Control/Monad/Reader.hm
@@ -1,0 +1,25 @@
+module Control.Monad.Reader where
+
+import Data.Functor (class Functor)
+import Control.Monad (class Applicative, class Monad)
+
+data Reader e a = Reader (e -> a)
+
+runReader :: forall e a. Reader e a -> e -> a
+runReader (Reader r) = r
+
+instance Functor (Reader e) where
+  map f (Reader r) = Reader (\e -> f (r e))
+
+instance Applicative (Reader e) where
+  pure a = Reader (\_ -> a)
+  apply (Reader f) (Reader r) = Reader (\e -> (f e) (r e))
+
+instance Monad (Reader e) where
+  bind (Reader r) f = Reader (\e -> runReader (f (r e)) e)
+
+ask :: forall e. Reader e e
+ask = Reader (\e -> e)
+
+local :: forall e a. (e -> a) -> Reader e a
+local f = Reader (\e -> f e)

--- a/tests/Test.hm
+++ b/tests/Test.hm
@@ -45,6 +45,7 @@ import Test.Database.Mnesia as Mnesia
 import Test.System.IO as IO
 
 import Test.Control.Monad as Monad
+import Test.Control.Monad.Reader as Reader
 
 import Test.Control.ReceiveSyntax as Rec
 import Test.System.Timer as Timer
@@ -100,6 +101,8 @@ main = runTest $ TxG "lib"
      TxG "Control" [ TxG "Process"   [Proc.test]
 
                    , TxG "Monad" [Monad.test]
+                   , TxG "Monads" [ TxG "Reader" [Reader.test]
+                                  ]
 
                    , TxG "ReceiveSyntax" [Rec.test]
 

--- a/tests/Test/Control/Monad/Reader.hm
+++ b/tests/Test/Control/Monad/Reader.hm
@@ -1,0 +1,11 @@
+module Test.Control.Monad.Reader where
+
+import Test.QuickCheck (TestGroup(..), TestResult, quickCheck1)
+import Prelude (IO, (==), (+))
+import Control.Monad.Reader (runReader, ask, local)
+
+test :: TestGroup (Integer -> IO TestResult)
+test = Exe [
+  quickCheck1 "ask" (runReader ask 1 == 1),
+  quickCheck1 "local" (runReader (local (\x -> x + x)) 2 == 4)
+]


### PR DESCRIPTION
use `newtype` instead of `data` will cause `badarity` error