### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ $ brew install hamler
   > -- get, put
   > Map.get "foo" m -- a = "bar"
   > Map.get "bar" m -- b = "foo"
-  > m1 = Map.put "key" "val"
+  > m1 = Map.put "key" "val" m
   > -- keys, values
   > keys = Map.keys m
   > values = Map.values m


### PR DESCRIPTION
Example in README.md has a typo.