### PR TITLE
Fix Build on CI - Github Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
           run: |
             sudo apt update && sudo apt install -y locales
             sudo locale-gen en_US.UTF-8
-            echo "::set-env name=LC_ALL::en_US.UTF-8"
+            echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
         - name: install library
           run: |
             sudo apt update && sudo apt install -y libtinfo-dev ghc
@@ -92,8 +92,8 @@ jobs:
           echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
           echo "LANG=en_US.UTF-8" > /etc/locale.conf
           locale-gen en_US.UTF-8
-          echo "::set-env name=LC_ALL::en_US.UTF-8"
-          echo "::set-env name=STACK_ROOT::$(pwd)"
+          echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+          echo "STACK_ROOT=$(pwd)" >> $GITHUB_ENV
           echo "::add-path::~/.local/bin"
       - name: install library
         run: |
@@ -166,8 +166,8 @@ jobs:
           yum install -y erlang-${OTP_VERSION}
       - name: set env
         run: |
-          echo "::set-env name=LC_ALL::en_US.UTF-8"
-          echo "::set-env name=STACK_ROOT::$(pwd)"
+          echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
+          echo "STACK_ROOT=$(pwd)" >> $GITHUB_ENV
           echo "::add-path::~/.local/bin"
       - name: install library
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,7 @@ jobs:
         - name: install library
           run: |
             sudo apt update && sudo apt install -y libtinfo-dev ghc
-            echo "::add-path::~/.local/bin"
+            echo "~/.local/bin" >> $GITHUB_PATH
             curl -sSL https://get.haskellstack.org/ | sh -s - -f
         - uses: actions/checkout@v2
         - name: make
@@ -94,7 +94,7 @@ jobs:
           locale-gen en_US.UTF-8
           echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
           echo "STACK_ROOT=$(pwd)" >> $GITHUB_ENV
-          echo "::add-path::~/.local/bin"
+          echo "~/.local/bin" >> $GITHUB_PATH
       - name: install library
         run: |
           apt update && apt install -y libtinfo-dev ghc
@@ -168,7 +168,7 @@ jobs:
         run: |
           echo "LC_ALL=en_US.UTF-8" >> $GITHUB_ENV
           echo "STACK_ROOT=$(pwd)" >> $GITHUB_ENV
-          echo "::add-path::~/.local/bin"
+          echo "~/.local/bin" >> $GITHUB_PATH
       - name: install library
         run: |
           yum install -y ghc
@@ -223,9 +223,9 @@ jobs:
           /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
           brew install gnu-sed erlang@23 haskell-stack
           ln -s /usr/local/bin/gsed /usr/local/bin/sed
-          echo "::add-path::/usr/local/opt/erlang@23/bin"
-          echo "::add-path::/usr/local/lib/hamler/bin"
-          echo "::add-path::/usr/local/bin"
+          echo "/usr/local/opt/erlang@23/bin" >> $GITHUB_PATH
+          echo "/usr/local/lib/hamler/bin" >> $GITHUB_PATH
+          echo "/usr/local/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v2
       - name: make
         run: |


### PR DESCRIPTION
This PR fixes the current issues in the Github Actions.

Github deprecated the way we were setting the environment variables and also the path. [More info.](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)
I just updated the `build.yaml` to use the new instructions to set both `PATH` and environment variables.

Keep up the amazing work and thanks for your time! 💐 
